### PR TITLE
Allow Solidus 4

### DIFF
--- a/solidus_jwt.gemspec
+++ b/solidus_jwt.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jwt'
   s.add_dependency 'solidus_auth_devise'
-  s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
+  s.add_dependency 'solidus_core', ['>= 2.0.0', '< 5']
   s.add_dependency 'solidus_support'
 
   s.add_development_dependency 'byebug'


### PR DESCRIPTION
We need to loosen the gemspec to allow for the main MA codebase to be upgraded to Solidus 4.0+.